### PR TITLE
Add aspnet/Extensions to tab view

### DIFF
--- a/Shared/TacticTabView.razor
+++ b/Shared/TacticTabView.razor
@@ -3,6 +3,9 @@
         <RadzenTabsItem Text="AspNetCore">
             <GridList OrgName="aspnet" RepoName="AspNetCore" Label="@Label" IsOpen="@IsOpenOnly" EnableApproval="@EnableApproval" />
         </RadzenTabsItem>
+        <RadzenTabsItem Text="Extensions">
+            <GridList OrgName="aspnet" RepoName="Extensions" Label="@Label" IsOpen="@IsOpenOnly" EnableApproval="@EnableApproval" />
+        </RadzenTabsItem>
         <RadzenTabsItem Text="CoreCLR">
             <GridList OrgName="dotnet" RepoName="CoreCLR" Label="@Label" IsOpen="@IsOpenOnly" EnableApproval="@EnableApproval" />
         </RadzenTabsItem>


### PR DESCRIPTION
It wasn't there. Fortunately we don't seem to have missed anything labelled `servicing-consider` in that repo.