### PR TITLE
add nuget

### DIFF
--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -6,6 +6,6 @@
       "Microsoft": "Information"
     }
   },
-  "REPO_LIST": "dotnet/aspnetcore,dotnet/coreclr,dotnet/core-setup,dotnet/cli,dotnet/corefx,dotnet/efcore,microsoft/msbuild,dotnet/sdk,dotnet/templating,dotnet/wcf,aspnet/websdk,dotnet/winforms,dotnet/wpf,dotnet/toolset,dotnet/runtime",
+  "REPO_LIST": "dotnet/aspnetcore,dotnet/coreclr,dotnet/core-setup,dotnet/cli,dotnet/corefx,dotnet/efcore,microsoft/msbuild,dotnet/sdk,dotnet/templating,dotnet/wcf,aspnet/websdk,dotnet/winforms,dotnet/wpf,dotnet/toolset,dotnet/runtime,nuget/nuget.client",
   "DEBUG_REPO_DATA": "false"
 }


### PR DESCRIPTION
this seems like the right place? (assuming you run in production using appsettings.Development.json?)

I didn't test it. 😃 

cc @aortiz-msft  after this is done, you can mark bugs for tactics with a label named "servicing-consider" and they will appear in https://tacticsview.azurewebsites.net/. No emails required.

cc @leecow